### PR TITLE
WW-1695 add support for .mjs files

### DIFF
--- a/bin/controllers/build.js
+++ b/bin/controllers/build.js
@@ -139,6 +139,11 @@ exports.build = (name, type) => {
                         test: /\.js$/,
                         loader: "babel-loader",
                     },
+                    {
+                        test: /\.mjs$/,
+                        include: /node_modules/,
+                        type: "javascript/auto"
+                    },
                     // this will apply to both plain `.css` files
                     // AND `<style>` blocks in `.vue` files
                     {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -131,6 +131,11 @@ module.exports = function() {
                     test: /\.js$/,
                     loader: "babel-loader",
                 },
+                {
+                    test: /\.mjs$/,
+                    include: /node_modules/,
+                    type: "javascript/auto"
+                },
                 // this will apply to both plain `.css` files
                 // AND `<style>` blocks in `.vue` files
                 {


### PR DESCRIPTION
Recently I struggled with custom components importing .mjs files because the webpack configuration does not handle them.
For example if you try to import anything from `vueuse` ([see here](https://github.com/vueuse/vueuse/blob/01a7ab4ebe8d860829d5c0328d887d0a274fb856/packages/core/package.json#L37)) both serving and building the component fail.

This is probably going to be a problem if you need to update `@vueform/multiselect` above v2.6.0 for `ww-input-multiselect` because the `module` [will point to a .mjs file](https://github.com/vueform/multiselect/blob/493be353e7db52e8600f38052ac27e654b533804/package.json#L10).

I added a basic rule to handle .mjs files and build an example component both locally and in the Weweb dashboard. It looks like it's working properly, but of course I can't test it to see if it can create problems across your whole system.

If you want to try it the sample component is [here](https://github.com/Dorilama/weweb-test-mjs) and the id of the weweb project where it's working is `01e301e3-44aa-4589-8cf6-81e9b4767762`.

Cheers.