### PR TITLE
Add pkg.pr.new support for preview releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,34 @@
+name: Publish PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+      - "**"
+    tags:
+      - "!**"
+
+jobs:
+  publish-preview:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build package
+        run: npm run build --if-present
+        
+      - name: Publish preview
+        run: npx pkg-pr-new publish

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -3,12 +3,6 @@ name: Publish PR Preview
 on:
   pull_request:
     types: [opened, synchronize]
-  push:
-    branches:
-      - main
-      - "**"
-    tags:
-      - "!**"
 
 jobs:
   publish-preview:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,178 @@
 # WeWeb CLI
 
-#### Serve :
+[![pkg.pr.new](https://pkg.pr.new/badge/weweb-team/weweb-cli)](https://pkg.pr.new/~/weweb-team/weweb-cli)
+
+Command-line interface for building WeWeb components (elements, sections, and plugins).
+
+## Installation
+
+```bash
+npm install -g @weweb/cli
+```
+
+## Usage
+
+### Single Component Mode
+
+For traditional single-component repositories:
+
+#### Serve
 
 > Default port is 8080.
 
-`npm run weweb serve [-- port=port]`
+```bash
+npm run weweb serve [-- port=port]
+yarn weweb serve [-- port=port]
+```
 
-`yarn weweb serve [-- port=port]`
+#### Build
 
-#### Build :
+```bash
+npm run weweb build -- name=name type=type
+yarn weweb build -- name=name type=type
+```
 
-`npm run weweb build -- name=name type=type`
+### Monorepo Mode
 
-`yarn weweb build -- name=name type=type`
+The CLI now supports monorepos containing multiple WeWeb components in a single repository.
+
+#### Setting up a Monorepo
+
+Create a `package.json` in your monorepo root with the following structure:
+
+```json
+{
+  "name": "@myorg/weweb-components-monorepo",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "weweb build",
+    "build:custom": "weweb build --output=my-components.js",
+    "list": "weweb list"
+  },
+  "weweb": {
+    "monorepo": true,
+    "components": [
+      {
+        "name": "my-button",
+        "path": "components/my-button",
+        "type": "element"
+      },
+      {
+        "name": "my-hero-section",
+        "path": "components/my-hero-section",
+        "type": "section"
+      },
+      {
+        "name": "my-analytics",
+        "path": "components/my-analytics",
+        "type": "plugin"
+      }
+    ]
+  },
+  "devDependencies": {
+    "@weweb/cli": "latest"
+  }
+}
+```
+
+#### Monorepo Structure
+
+```
+my-monorepo/
+├── package.json
+├── components/
+│   ├── my-button/
+│   │   ├── package.json
+│   │   ├── ww-config.js
+│   │   └── src/
+│   │       └── wwElement.vue
+│   ├── my-hero-section/
+│   │   ├── package.json
+│   │   ├── ww-config.js
+│   │   └── src/
+│   │       └── wwSection.vue
+│   └── my-analytics/
+│       ├── package.json
+│       ├── ww-config.js
+│       └── src/
+│           └── wwPlugin.js
+└── dist/
+    └── monorepo-bundle.js
+```
+
+#### Monorepo Commands
+
+```bash
+# List all components in the monorepo
+weweb list
+
+# Build all components into a single bundle
+weweb build
+
+# Build with custom output filename
+weweb build --output=my-components.js
+```
+
+#### Monorepo Benefits
+
+1. **Single Bundle**: All components are bundled into one JavaScript file, enabling better tree-shaking and optimization
+2. **Unified Versioning**: All components share the same version from the root package.json
+3. **Easier Maintenance**: Manage dependencies and tooling in one place
+4. **Better Code Sharing**: Components can share utilities and common code
+
+#### Component Configuration
+
+The `weweb.components` array supports multiple formats:
+
+```json
+// Object format with explicit configuration
+{
+  "components": [
+    {
+      "name": "my-button",
+      "path": "components/my-button",
+      "type": "element"  // "element", "section", or "plugin"
+    }
+  ]
+}
+
+// Object map format
+{
+  "components": {
+    "my-button": {
+      "path": "components/my-button",
+      "type": "element"
+    }
+  }
+}
+
+// Simple array format (type will be auto-detected)
+{
+  "components": [
+    "components/my-button",
+    "components/my-section"
+  ]
+}
+```
+
+## Build Output
+
+### Single Component Mode
+- Output: `dist/manager.js`
+- Contains: One component
+
+### Monorepo Mode
+- Output: `dist/monorepo-bundle.js` (or custom name via `--output`)
+- Contains: All components in a single bundle
+- Automatically registers all components when loaded
+
+## Requirements
+
+- Node.js 14+
+- Each component must have:
+  - A `ww-config.js` or `ww-config.json` file
+  - A component file (`wwElement.vue`, `wwSection.vue`, or `wwPlugin.js`)
+
+## Tree Shaking
+
+In monorepo mode, the bundle is optimized for tree shaking. WeWeb will only load the components that are actually used in a project, even though all components are included in the bundle.


### PR DESCRIPTION
## Summary
- Add pkg.pr.new GitHub Actions workflow to enable preview releases on every PR and push
- Add pkg.pr.new badge to README
- This allows testing lambda-component-builder with unreleased CLI changes

## Test plan
- [ ] Install pkg.pr.new GitHub app on this repository
- [ ] Verify workflow runs on this PR
- [ ] Test preview URL in lambda-component-builder