### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-slack-notifs.yml
+++ b/.github/workflows/dependabot-slack-notifs.yml
@@ -1,6 +1,10 @@
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   slack_notif:
     if: startsWith(github.head_ref, 'dependabot/')


### PR DESCRIPTION
Potential fix for [https://github.com/weweb-team/weweb-cli/security/code-scanning/2](https://github.com/weweb-team/weweb-cli/security/code-scanning/2)

The fix is to add an explicit `permissions` block to the workflow, granting only the minimal required privileges for the steps contained. In this case, the workflow simply reads pull request data and sends a Slack notification — it does not perform any GitHub API write actions. Therefore, setting permissions to either `read-all` (for full read-only access) or a more restricted set (like just `contents: read` or `pull-requests: read`) is appropriate. The most minimal and future-proof approach is usually to add a workflow-level block (at the top, after `on`) like:

```yaml
permissions:
  contents: read
  pull-requests: read
```

This should be placed just after the `on:` block and before `jobs:`. No imports, definitions, or logic changes are needed elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
